### PR TITLE
Firestore rules: public read, admin (email) write for Posts/Images/Quotes

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,23 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    function isAdmin() {
+      return request.auth != null && request.auth.token.email == "jmjrice94@gmail.com";
+    }
+
+    match /Posts/{doc} {
+      allow read: if true;
+      allow create, update, delete: if isAdmin();
+    }
+
+    match /Images/{doc} {
+      allow read: if true;
+      allow create, update, delete: if isAdmin();
+    }
+
+    match /Quotes/{doc} {
+      allow read: if true;
+      allow create, update, delete: if isAdmin();
+    }
+  }
+}


### PR DESCRIPTION
### Motivation
- Allow public read access to site content stored in Firestore while restricting all writes to a single verified admin account.
- Ensure server-side identity verification is enforced in rules rather than relying on client-side checks or custom claims.
- Apply permissions explicitly per collection to prevent frontend changes from bypassing security.

### Description
- Add `firestore.rules` using `rules_version = '2'` with an `isAdmin()` helper that checks `request.auth != null` and `request.auth.token.email == "jmjrice94@gmail.com"`.
- Explicitly match `/Posts/{doc}`, `/Images/{doc}`, and `/Quotes/{doc}` and allow `read` for everyone while allowing `create`, `update`, and `delete` only if `isAdmin()` is true.
- Do not rely on custom claims, environment variables, or client-supplied data for authorization.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69659166d6408321860e99680be554bb)