### PR TITLE
Add Firebase Auth admin gating and UI guards

### DIFF
--- a/index.html
+++ b/index.html
@@ -111,6 +111,8 @@
     </div>
     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/js-yaml@4.1.0/dist/js-yaml.min.js"></script>
+    <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-app-compat.js"></script>
+    <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-auth-compat.js"></script>
     <script type="module" src="script.js"></script>
     <script>
       document.addEventListener("DOMContentLoaded", function() {


### PR DESCRIPTION
### Motivation

- Add Firebase Authentication to enable admin-only features on the site. 
- Track a single admin identity and show/hide editing UI based on sign-in state. 
- Prevent accidental or malicious exposure of admin controls by enforcing server-side-like checks in the client. 

### Description

- Include Firebase App/Auth compatibility SDKs in `index.html` by adding the `firebase-app-compat.js` and `firebase-auth-compat.js` script tags. 
- Initialize Firebase in `script.js` using `window.firebaseConfig` fallback and create an `auth` instance when available. 
- Add `onAuthStateChanged` handling to set an `isAdmin` boolean when `user?.email === 'jmjrice94@gmail.com'` and expose `isAdminUser()` via `window`. 
- Add `updateAdminUi()` to show/hide elements marked with `data-admin-only`, `.editButton`, or `.editPanel` and add `ensureAdmin()` with global click/submit guards that block admin actions unless `isAdmin` is true. 

### Testing

- No automated tests were run for this change. 
- Changes were applied as a static update and committed to the repository.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696595261ee08321aed4d82ddf0d6180)