### PR TITLE
Add admin-only portfolio editor UI and local edits

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,7 +47,10 @@
       </section>
       <div class="search"><input id="q" type="search" placeholder="Search posts and notes..."/></div>
       <section class="portfolio" id="about">
-        <h2>Portfolio</h2>
+        <div class="sectionHeader">
+          <h2>Portfolio</h2>
+          <button id="editPortfolio" class="editBtn" type="button" hidden>Edit</button>
+        </div>
         <div class="subhead">Pinned</div>
         <div class="grid" id="pinnedGrid"></div>
         <div class="subhead">Posts</div>

--- a/styles.css
+++ b/styles.css
@@ -257,6 +257,34 @@
     font-size: 1rem;
     text-decoration: underline;
   }
+
+  .sectionHeader {
+    display: flex;
+    align-items: center;
+    gap: .75rem;
+  }
+
+  .sectionHeader h2 {
+    margin: 0;
+  }
+
+  .sectionHeader .editBtn {
+    margin-left: auto;
+    padding: .25rem .65rem;
+    font-size: .75rem;
+    text-transform: uppercase;
+    letter-spacing: .08em;
+    font-family: var(--fontHead);
+    border: 1px solid rgba(255,255,255,.8);
+    background: rgba(0,0,0,.15);
+    color: #fff;
+    cursor: pointer;
+  }
+
+  .sectionHeader .editBtn:hover {
+    background: #fff;
+    color: var(--green);
+  }
   
   /* Grid & entries */
   .grid {
@@ -359,6 +387,44 @@
   
   #postView.show #postContent {
     transform: scale(1);
+  }
+
+  #postView.editorMode #postContent {
+    max-width: min(920px, 94vw);
+  }
+
+  .postEditor {
+    width: 100%;
+    min-height: 50vh;
+    padding: 1rem;
+    border: 1px solid var(--border);
+    background: #f8f8f8;
+    color: #222;
+    font-family: 'Fira Code', 'Courier New', monospace;
+    font-size: .95rem;
+    resize: vertical;
+  }
+
+  .editorControls {
+    display: flex;
+    justify-content: flex-end;
+    gap: .6rem;
+    margin-top: 1rem;
+  }
+
+  .editorControls button {
+    border: 1px solid var(--border);
+    padding: .4rem .9rem;
+    font-family: var(--fontHead);
+    cursor: pointer;
+  }
+
+  .editorControls .saveBtn {
+    background: var(--yellow);
+  }
+
+  .editorControls .cancelBtn {
+    background: var(--bg);
   }
   
   /* Post content styling */


### PR DESCRIPTION
### Motivation

- Allow admins to quickly edit Portfolio posts directly from the site by adding an inline Edit control guarded by an `isAdmin` flag.
- Provide a simple modal editor inside the existing `#postView` so posts can be toggled into editable form and saved without changing the static site build process.
- Keep normal post rendering and UX for non-admin users while enabling Save/Cancel controls and a small set of editor styles for admin workflows.

### Description

- Wrapped the Portfolio heading in a flex container and added an admin-only `<button id="editPortfolio">` in `index.html`.
- Added `.sectionHeader`, `.editBtn`, `.postEditor`, `.editorControls`, and `#postView.editorMode` styles to `styles.css` for compact, right-aligned edit controls and editor layout.
- Implemented admin-gated editor logic in `script.js` including reading `isAdmin` from `localStorage`, `enterEditorMode`/`exitEditorMode`, `currentPost` state, and rendering via `marked`.
- Persist edits locally to `localStorage` under the key ``postEdit:${url}`` and load stored content when opening posts so Save updates the displayed content.

### Testing

- Launched a local static server using `python -m http.server` to serve the site and it started successfully.
- Ran an automated Playwright script to verify the UI and capture a screenshot, but the Playwright run timed out and failed.
- No unit or integration tests were executed against application logic during this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965952e58a88321a20e367b5719e183)