### PR TITLE
Fix admin email login flow and add login modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
         <a href="https://joerice.me/#contact">Contact Me</a>
         <a href="https://joerice.me/#quotes">Quotes</a>
         <a href="https://joerice.me/#links">Useful Links</a>
-        <a href="login.html">Login</a>
+        <button class="navButton" id="loginButton" type="button">Login</button>
       </nav>
     </header>
     <main class="max">
@@ -138,6 +138,21 @@
     <footer>© <span id="year"></span> Joe Rice. All rights reserved.</footer>
     <div class="modal" id="modal">
       <div class="modalContent"><p>Thank you! Your message has been sent.</p><button id="closeModal" style="margin-top:1rem; border:1px solid var(--border); padding:.5rem 1rem; background:var(--yellow); font-family:var(--fontHead); cursor:pointer;">close</button></div>
+    </div>
+    <div class="modal loginModal" id="loginModal" aria-hidden="true">
+      <div class="modalContent">
+        <h3>Admin login</h3>
+        <p>Enter your email to receive a sign-in link.</p>
+        <form id="loginForm">
+          <label for="loginEmail">Email</label>
+          <input id="loginEmail" type="email" autocomplete="email" required/>
+          <div class="loginActions">
+            <button class="loginSendButton" type="submit">Send login link</button>
+            <button class="loginCancelButton" id="loginCancel" type="button">Cancel</button>
+          </div>
+        </form>
+        <p class="loginStatus" id="loginStatus" role="status" aria-live="polite"></p>
+      </div>
     </div>
     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/js-yaml@4.1.0/dist/js-yaml.min.js"></script>

--- a/styles.css
+++ b/styles.css
@@ -122,17 +122,24 @@
     gap: clamp(12px, 2vw, 24px);
   }
   
-  #mainNav a {
+  #mainNav a,
+  #mainNav button {
     font-family: var(--fontHead);
     border: 1px solid var(--border);
     padding: .3rem .7rem;
     white-space: nowrap;
     transition: background .2s;
   }
-  
-  #mainNav a:hover {
+
+  #mainNav a:hover,
+  #mainNav button:hover {
     background: var(--fg);
     color: var(--bg);
+  }
+
+  #mainNav button {
+    background: transparent;
+    cursor: pointer;
   }
   
   .menuToggle {
@@ -172,7 +179,8 @@
     #mainNav.open {
       transform: scaleY(1);
     }
-    #mainNav a {
+    #mainNav a,
+    #mainNav button {
       width: 100%;
       border-width: 1px 0 0;
       padding: .5rem 0;
@@ -831,6 +839,56 @@
     max-width: 320px;
     text-align: center;
     font-size: 1rem;
+  }
+
+  .loginModal .modalContent {
+    max-width: 360px;
+    text-align: left;
+  }
+
+  .loginModal h3 {
+    margin-top: 0;
+  }
+
+  .loginModal form {
+    display: grid;
+    gap: .75rem;
+    margin-top: 1rem;
+  }
+
+  .loginModal input {
+    border: 1px solid var(--border);
+    padding: .5rem;
+    font-family: var(--font);
+  }
+
+  .loginActions {
+    display: flex;
+    gap: .5rem;
+    flex-wrap: wrap;
+  }
+
+  .loginSendButton,
+  .loginCancelButton {
+    border: 1px solid var(--border);
+    padding: .45rem .9rem;
+    font-family: var(--fontHead);
+    cursor: pointer;
+  }
+
+  .loginSendButton {
+    background: var(--green);
+    color: #fff;
+  }
+
+  .loginCancelButton {
+    background: transparent;
+  }
+
+  .loginStatus {
+    margin-top: .75rem;
+    min-height: 1.2rem;
+    color: var(--blue);
   }
   
   /* Links section */


### PR DESCRIPTION
### Motivation
- Replace the old `login.html` link with an in-page flow so admins can sign in via an email link and see admin controls without a separate page. 
- Ensure admin-only UI (edit controls) is revealed after Firebase email-link authentication for the configured admin email `jmjrice94@gmail.com`.
- Provide an accessible modal UI that guides users through sending and completing email-link sign-in.

### Description
- Replaced the nav login anchor with a `button` (`#loginButton`) and added a modal markup (`#loginModal`) and form (`#loginForm`) in `index.html` for email link sign-in.  
- Implemented client behavior in `script.js` to send email sign-in links via `auth.sendSignInLinkToEmail`, persist `emailForSignIn` to `localStorage`, detect `auth.isSignInWithEmailLink`, and complete sign-in with `auth.signInWithEmailLink`.  
- Updated admin visibility logic to include `.editBtn` elements and to update the login button text when signed in via `updateAdminUi`.  
- Added styling in `styles.css` for nav buttons and the new login modal including `.loginModal`, `.loginSendButton`, `.loginStatus`, and responsive nav button rules. 

### Testing
- Started a local server with `python -m http.server 8000` which served the site successfully.  
- Attempted an automated smoke test with Playwright that clicked `#loginButton` and took a screenshot, but the Playwright run crashed (SIGSEGV) and failed.  
- No unit tests are present or run for this change.  
- All changes were lint/format-free edits to HTML/CSS/JS and committed after verification of file updates.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965a494e144832196cb4993b1465f55)