### PR TITLE
Add DOM helpers and safer element queries

### DIFF
--- a/assets/js/auth.js
+++ b/assets/js/auth.js
@@ -1,3 +1,4 @@
+import { $, $$ } from './dom.js';
 import { lockScroll, unlockScroll } from './ui/layout.js';
 
 const firebaseConfig = window.firebaseConfig || {
@@ -21,7 +22,7 @@ export function isAdminUser() {
 }
 
 export function updateAdminUi() {
-  const adminOnlyElements = document.querySelectorAll(
+  const adminOnlyElements = $$(
     '[data-admin-only], .editButton, .editBtn, .editPanel'
   );
   adminOnlyElements.forEach(el => {
@@ -31,7 +32,7 @@ export function updateAdminUi() {
     el.classList.toggle('admin-hidden', shouldHide);
   });
 
-  const loginButton = document.getElementById('loginButton');
+  const loginButton = $('#loginButton');
   if (loginButton) {
     loginButton.textContent = isAdmin ? 'Admin' : 'Login';
   }
@@ -48,14 +49,14 @@ export function getFirestore() {
 }
 
 function setLoginStatus(message = '') {
-  const loginStatus = document.getElementById('loginStatus');
+  const loginStatus = $('#loginStatus');
   if (!loginStatus) return;
   loginStatus.textContent = message;
 }
 
 function openLoginModal() {
-  const loginModal = document.getElementById('loginModal');
-  const loginEmail = document.getElementById('loginEmail');
+  const loginModal = $('#loginModal');
+  const loginEmail = $('#loginEmail');
   if (!loginModal) return;
   loginModal.classList.add('show');
   loginModal.setAttribute('aria-hidden', 'false');
@@ -64,7 +65,7 @@ function openLoginModal() {
 }
 
 function closeLoginModal() {
-  const loginModal = document.getElementById('loginModal');
+  const loginModal = $('#loginModal');
   if (!loginModal) return;
   loginModal.classList.remove('show');
   loginModal.setAttribute('aria-hidden', 'true');
@@ -128,11 +129,11 @@ export function initAuth() {
 
   window.isAdminUser = isAdminUser;
 
-  const loginButton = document.getElementById('loginButton');
-  const loginModal = document.getElementById('loginModal');
-  const loginForm = document.getElementById('loginForm');
-  const loginEmail = document.getElementById('loginEmail');
-  const loginCancel = document.getElementById('loginCancel');
+  const loginButton = $('#loginButton');
+  const loginModal = $('#loginModal');
+  const loginForm = $('#loginForm');
+  const loginEmail = $('#loginEmail');
+  const loginCancel = $('#loginCancel');
 
   if (loginButton) {
     loginButton.addEventListener('click', () => {
@@ -208,8 +209,8 @@ export function initAuth() {
     }
   });
 
-  document.querySelectorAll('.editButton[data-panel-target], .editBtn[data-panel-target]').forEach(button => {
-    const panel = document.getElementById(button.dataset.panelTarget);
+  $$('.editButton[data-panel-target], .editBtn[data-panel-target]').forEach(button => {
+    const panel = $(`#${button.dataset.panelTarget}`);
     if (panel) {
       button.setAttribute('aria-expanded', String(!panel.classList.contains('is-collapsed')));
     }

--- a/assets/js/contact.js
+++ b/assets/js/contact.js
@@ -1,3 +1,5 @@
+import { $ } from './dom.js';
+
 let modal = null;
 let closeModalButton = null;
 let contactForm = null;
@@ -13,9 +15,9 @@ function hideModal() {
 }
 
 export function initContact() {
-  modal = document.getElementById('modal');
-  closeModalButton = document.getElementById('closeModal');
-  contactForm = document.getElementById('contactForm');
+  modal = $('#modal');
+  closeModalButton = $('#closeModal');
+  contactForm = $('#contactForm');
 
   if (closeModalButton) {
     closeModalButton.addEventListener('click', hideModal);

--- a/assets/js/dom.js
+++ b/assets/js/dom.js
@@ -1,0 +1,2 @@
+export const $ = (selector, root = document) => root.querySelector(selector);
+export const $$ = (selector, root = document) => Array.from(root.querySelectorAll(selector));

--- a/assets/js/posts.js
+++ b/assets/js/posts.js
@@ -1,4 +1,5 @@
 import { ensureAdmin, isAdminUser } from './auth.js';
+import { $, $$ } from './dom.js';
 import { lockScroll, unlockScroll } from './ui/layout.js';
 
 const pinned = [];
@@ -31,9 +32,9 @@ function setPortfolioStatus(message) {
 }
 
 function attachClickHandlers() {
-  document.querySelectorAll('.entry').forEach(el => {
+  $$('.entry').forEach(el => {
     el.addEventListener('click', async () => {
-      document.querySelectorAll('.entry.active').forEach(a => a.classList.remove('active'));
+      $$('.entry.active').forEach(a => a.classList.remove('active'));
       el.classList.add('active');
       await openPost(el.dataset.url);
     });
@@ -41,7 +42,7 @@ function attachClickHandlers() {
 }
 
 function filterEntries() {
-  document.querySelectorAll('.entry').forEach(el => {
+  $$('.entry').forEach(el => {
     const tags = (el.dataset.tags || '').split('|');
     const hide = selectedTags.size &&
                  ![...selectedTags].some(t => tags.includes(t));
@@ -138,22 +139,22 @@ async function loadPosts() {
 }
 
 export function initPosts() {
-  pinnedGrid = document.getElementById('pinnedGrid');
-  entryGrid = document.getElementById('entryGrid');
-  prevBtn = document.getElementById('prevBtn');
-  nextBtn = document.getElementById('nextBtn');
-  postView = document.getElementById('postView');
-  postContentEl = document.getElementById('postContentInner');
-  closePostBtn = document.getElementById('closePost');
-  portfolioStatus = document.getElementById('portfolioStatus');
-  editPortfolioBtn = document.getElementById('editPortfolioBtn');
-  searchInput = document.getElementById('q');
+  pinnedGrid = $('#pinnedGrid');
+  entryGrid = $('#entryGrid');
+  prevBtn = $('#prevBtn');
+  nextBtn = $('#nextBtn');
+  postView = $('#postView');
+  postContentEl = $('#postContentInner');
+  closePostBtn = $('#closePost');
+  portfolioStatus = $('#portfolioStatus');
+  editPortfolioBtn = $('#editPortfolioBtn');
+  searchInput = $('#q');
 
   if (!pinnedGrid || !entryGrid) return;
 
   if (closePostBtn) {
     closePostBtn.addEventListener('click', () => {
-      document.querySelectorAll('.entry.active').forEach(a => a.classList.remove('active'));
+      $$('.entry.active').forEach(a => a.classList.remove('active'));
       if (postView) postView.classList.remove('show');
       unlockScroll();
       if (typeof window.exitEditorMode === 'function') {
@@ -168,7 +169,7 @@ export function initPosts() {
       if (!ensureAdmin('edit portfolio')) return;
       let targetUrl = currentPost?.url;
       if (!targetUrl) {
-        const activeEntry = document.querySelector('.entry.active');
+        const activeEntry = $('.entry.active');
         targetUrl = activeEntry?.dataset.url;
       }
       if (!targetUrl) return;
@@ -184,13 +185,13 @@ export function initPosts() {
   if (searchInput) {
     searchInput.addEventListener('input', e => {
       const v = e.target.value.toLowerCase();
-      document.querySelectorAll('.entry').forEach(el => {
+      $$('.entry').forEach(el => {
         el.style.display = el.textContent.toLowerCase().includes(v) ? '' : 'none';
       });
     });
   }
 
-  document.querySelectorAll('.filterBtn').forEach(btn => {
+  $$('.filterBtn').forEach(btn => {
     btn.addEventListener('click', () => {
       const tag = btn.dataset.tag;
       btn.classList.toggle('active');

--- a/assets/js/quotes.js
+++ b/assets/js/quotes.js
@@ -1,4 +1,5 @@
 import { ensureAdmin, getFirestore } from './auth.js';
+import { $ } from './dom.js';
 
 let quoteBox = null;
 let quoteText = null;
@@ -109,17 +110,17 @@ async function initQuoteData() {
 }
 
 export function initQuotes() {
-  quoteBox = document.getElementById('quoteBox');
-  quoteText = document.getElementById('quoteText');
-  quoteCite = document.getElementById('quoteCite');
-  progBar = document.getElementById('quoteProgress');
-  quoteStatus = document.getElementById('quoteStatus');
-  quoteListItems = document.getElementById('quoteListItems');
-  quoteEditorPane = document.getElementById('quoteEditorPane');
-  quoteEditorText = document.getElementById('quoteEditorText');
-  quoteEditorAuthor = document.getElementById('quoteEditorAuthor');
-  quoteSaveButton = document.getElementById('quoteSaveButton');
-  quoteAddButton = document.querySelector('.quoteAddButton');
+  quoteBox = $('#quoteBox');
+  quoteText = $('#quoteText');
+  quoteCite = $('#quoteCite');
+  progBar = $('#quoteProgress');
+  quoteStatus = $('#quoteStatus');
+  quoteListItems = $('#quoteListItems');
+  quoteEditorPane = $('#quoteEditorPane');
+  quoteEditorText = $('#quoteEditorText');
+  quoteEditorAuthor = $('#quoteEditorAuthor');
+  quoteSaveButton = $('#quoteSaveButton');
+  quoteAddButton = $('.quoteAddButton');
 
   const firestore = getFirestore();
   quotesDocRef = firestore ? firestore.collection('siteContent').doc('quotes') : null;

--- a/assets/js/tooltips.js
+++ b/assets/js/tooltips.js
@@ -1,21 +1,23 @@
+import { $$ } from './dom.js';
+
 const colors = ['var(--blue)', 'var(--red)', 'var(--yellow)', 'var(--rose)', 'var(--green)', 'var(--purple)'];
 
 export function initTooltips() {
   const mobile = !matchMedia('(hover: hover)').matches;
 
   if (mobile) {
-    document.querySelectorAll('.galleryGrid img').forEach(img => {
+    $$('.galleryGrid img').forEach(img => {
       img.parentElement?.addEventListener('click', e => {
         if (!img.classList.contains('tapped')) {
           e.preventDefault();
-          document.querySelectorAll('.galleryGrid img').forEach(i => i.classList.remove('tapped'));
+          $$('.galleryGrid img').forEach(i => i.classList.remove('tapped'));
           img.classList.add('tapped');
         }
       });
     });
   }
 
-  document.querySelectorAll('.social a').forEach(a => {
+  $$('.social a').forEach(a => {
     const tip = document.createElement('span');
     tip.className = 'tooltip';
     tip.textContent = a.dataset.tip;
@@ -38,7 +40,7 @@ export function initTooltips() {
     a.addEventListener('click', e => {
       if (mobile && !a.classList.contains('showTip')) {
         e.preventDefault();
-        document.querySelectorAll('.social a').forEach(l => {
+        $$('.social a').forEach(l => {
           l.classList.remove('showTip');
           l.style.color = 'inherit';
         });

--- a/assets/js/ui/layout.js
+++ b/assets/js/ui/layout.js
@@ -1,3 +1,5 @@
+import { $ } from '../dom.js';
+
 let scrollY = 0;
 
 export function lockScroll() {
@@ -15,7 +17,7 @@ export function unlockScroll() {
 }
 
 function updateHeaderHeight() {
-  const header = document.querySelector('.siteHeader');
+  const header = $('.siteHeader');
   if (!header) return;
   const height = header.offsetHeight;
   document.documentElement.style.setProperty('--header-h', `${height}px`);
@@ -25,8 +27,8 @@ export function initLayout() {
   updateHeaderHeight();
   window.addEventListener('resize', updateHeaderHeight);
 
-  const menuToggle = document.querySelector('.menuToggle');
-  const mainNav = document.getElementById('mainNav');
+  const menuToggle = $('.menuToggle');
+  const mainNav = $('#mainNav');
   if (menuToggle && mainNav) {
     menuToggle.addEventListener('click', () => mainNav.classList.toggle('open'));
   }


### PR DESCRIPTION
### Motivation
- Prevent accidental null dereferences when querying DOM elements by using centralized helpers and explicit null checks. 
- Simplify and standardize element selection across modules to reduce repetitive `document.querySelector*` usage. 
- Improve robustness of UI initialization and event wiring by making element access more consistent and easier to review.

### Description
- Add `assets/js/dom.js` exporting `$(selector, root)` and `$$(selector, root)` helper functions for single and multiple element queries. 
- Update `auth.js`, `contact.js`, `posts.js`, `quotes.js`, `tooltips.js`, and `ui/layout.js` to import and use `$(...)` / `$$(...)` instead of `getElementById` / `querySelectorAll` and keep null-checked element usage. 
- Replace bulk `document.querySelectorAll` and `document.getElementById` calls with the helpers and preserve existing guard clauses so event handlers and UI mutations only run when elements exist. 
- Adjust imports/paths where needed (e.g. `ui/layout.js` importing `../dom.js`).

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965aad9e3fc8321a5a63af02363fc06)