### PR TITLE
Route tag filtering through renderPage

### DIFF
--- a/assets/js/posts.js
+++ b/assets/js/posts.js
@@ -197,7 +197,7 @@ export function initPosts() {
       btn.classList.toggle('active');
       if (btn.classList.contains('active')) selectedTags.add(tag);
       else selectedTags.delete(tag);
-      filterEntries();
+      renderPage();
     });
   });
 


### PR DESCRIPTION
### Motivation
- Keep tag filtering behavior encapsulated in the posts module by routing updates through the page renderer.
- Make filtering explicit and consistent with pagination and rendering logic by having `renderPage()` perform filtering.
- Avoid duplicating filtering calls from multiple places and centralize state-driven UI updates.

### Description
- Replace the direct call to `filterEntries()` in the filter button click handler with a call to `renderPage()` so tag toggles go through the renderer.
- This leverages the existing `renderPage()` implementation which already calls `filterEntries()` after updating the entries.
- No other logic or public API surface was changed in `assets/js/posts.js`.

### Testing
- No automated tests were run for this change.
- A local commit was created containing the single-line replacement in `assets/js/posts.js`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965abfd981083219f32744c5104065e)