### PR TITLE
Add non-JS fallback and fix hash handling for login modal

### DIFF
--- a/assets/js/auth.js
+++ b/assets/js/auth.js
@@ -64,13 +64,17 @@ function openLoginModal() {
   lockScroll();
 }
 
-function closeLoginModal() {
+function closeLoginModal(event) {
+  event?.preventDefault();
   const loginModal = $('#loginModal');
   if (!loginModal) return;
   loginModal.classList.remove('show');
   loginModal.setAttribute('aria-hidden', 'true');
   setLoginStatus('');
   unlockScroll();
+  if (window.location.hash === '#loginModal') {
+    history.replaceState(null, '', window.location.pathname + window.location.search);
+  }
 }
 
 async function sendLoginLink(email) {
@@ -136,7 +140,8 @@ export function initAuth() {
   const loginCancel = $('#loginCancel');
 
   if (loginButton) {
-    loginButton.addEventListener('click', () => {
+    loginButton.addEventListener('click', event => {
+      event.preventDefault();
       if (isAdmin) {
         setLoginStatus('You are already signed in.');
       }

--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
         <a href="https://joerice.me/#contact">Contact Me</a>
         <a href="https://joerice.me/#quotes">Quotes</a>
         <a href="https://joerice.me/#links">Useful Links</a>
-        <button class="navButton" id="loginButton" type="button">Login</button>
+        <a class="navButton" id="loginButton" href="#loginModal">Login</a>
       </nav>
     </header>
     <main class="max">
@@ -139,7 +139,7 @@
     <div class="modal" id="modal">
       <div class="modalContent"><p>Thank you! Your message has been sent.</p><button id="closeModal" style="margin-top:1rem; border:1px solid var(--border); padding:.5rem 1rem; background:var(--yellow); font-family:var(--fontHead); cursor:pointer;">close</button></div>
     </div>
-    <div class="modal loginModal" id="loginModal" aria-hidden="true">
+    <div class="modal loginModal" id="loginModal" aria-hidden="true" role="dialog" aria-modal="true">
       <div class="modalContent">
         <h3>Admin login</h3>
         <p>Enter your email to receive a sign-in link.</p>
@@ -148,7 +148,7 @@
           <input id="loginEmail" type="email" autocomplete="email" required/>
           <div class="loginActions">
             <button class="loginSendButton" type="submit">Send login link</button>
-            <button class="loginCancelButton" id="loginCancel" type="button">Cancel</button>
+            <a class="loginCancelButton" id="loginCancel" href="#" role="button">Cancel</a>
           </div>
         </form>
         <p class="loginStatus" id="loginStatus" role="status" aria-live="polite"></p>

--- a/styles.css
+++ b/styles.css
@@ -827,7 +827,8 @@
     transition: opacity .25s;
   }
   
-  .modal.show {
+  .modal.show,
+  .modal:target {
     opacity: 1;
     pointer-events: auto;
   }


### PR DESCRIPTION
### Motivation
- Provide a non-JS fallback so the login modal can be opened even when the JS handler doesn't attach. 
- Prevent the URL hash from being left set when the modal is opened/closed by JS, which could cause the modal to remain visible after navigation or refresh. 
- Improve accessibility by adding dialog semantics to the login modal. 

### Description
- Replace the header `button#loginButton` with an anchor fallback `a#loginButton[href="#loginModal"]` and change the cancel control to an anchor to support `:target` navigation in `index.html`. 
- Add `role="dialog"` and `aria-modal="true"` to the login modal container to improve semantics. 
- Extend modal CSS to show when targeted by using `.modal:target` in addition to `.modal.show` in `styles.css`. 
- Update `assets/js/auth.js` so the `loginButton` click handler uses `event.preventDefault()` and `closeLoginModal` clears the `#loginModal` hash via `history.replaceState` to avoid hash pollution when JS is active. 

### Testing
- Attempted an end-to-end check with a Playwright script to open the page and click `#loginButton` to verify modal visibility, but the Playwright run crashed in this environment and did not complete. 
- No other automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965b0d62a48832191f5edf526abb680)