### PR TITLE
Fix quotes YAML loading and error handling

### DIFF
--- a/assets/js/quotes.js
+++ b/assets/js/quotes.js
@@ -39,8 +39,16 @@ function showQuote(i) {
 }
 
 async function loadQuotesFromYaml() {
-  const qYaml = await fetch('quotes/quotes.yaml').then(r => r.text());
-  return jsyaml.load(qYaml).quotes || [];
+  const yamlUrl = new URL('../../quotes/quotes.yaml', import.meta.url);
+  const response = await fetch(yamlUrl);
+  if (!response.ok) {
+    throw new Error(`Unable to load quotes YAML (${response.status}).`);
+  }
+  const qYaml = await response.text();
+  if (!globalThis.jsyaml?.load) {
+    throw new Error('YAML parser not available.');
+  }
+  return globalThis.jsyaml.load(qYaml)?.quotes || [];
 }
 
 async function loadQuotes() {
@@ -106,7 +114,9 @@ async function initQuoteData() {
     if (!quotes.length) return;
     startQuoteCarousel();
     renderQuoteList(idx);
-  } catch {}
+  } catch (error) {
+    console.warn('Unable to load quotes.', error);
+  }
 }
 
 export function initQuotes() {


### PR DESCRIPTION
### Motivation
- The quotes carousel was failing to load YAML because the relative fetch path wasn't resolved from the module context.
- Failures were being swallowed silently, making debugging difficult.
- The YAML parser availability and HTTP response were not checked, leading to unclear runtime errors.

### Description
- Resolve the YAML file using a module-relative URL with `new URL('../../quotes/quotes.yaml', import.meta.url)` in `assets/js/quotes.js`.
- Fetch the YAML and check `response.ok`, throwing a descriptive error when loading fails.
- Verify the YAML parser exists via `globalThis.jsyaml?.load` before parsing and return `globalThis.jsyaml.load(qYaml)?.quotes || []`.
- Replace the empty `catch` in `initQuoteData` with a `console.warn('Unable to load quotes.', error)` to surface load failures.

### Testing
- No automated tests were executed for this change.
- The change was committed and the updated `assets/js/quotes.js` file contains the new loading and error handling logic.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965b163eebc8321bd6e68f96d1fa9ba)