### PR TITLE
Guard Firebase auth initialization when no app exists

### DIFF
--- a/assets/js/auth.js
+++ b/assets/js/auth.js
@@ -120,7 +120,7 @@ function initFirebase() {
       console.warn('Firebase config missing; auth is disabled.');
     }
   }
-  if (window.firebase?.auth) {
+  if (window.firebase?.apps?.length && window.firebase?.auth) {
     auth = window.firebase.auth();
   }
   if (window.firebase?.apps?.length && window.firebase?.firestore) {


### PR DESCRIPTION
### Motivation
- Prevent the runtime error "No Firebase App '[DEFAULT]' has been created" during login flows when Firebase hasn't been initialized.
- The code previously attempted to access `window.firebase.auth()` even if no Firebase app was present.

### Description
- Update `initFirebase` in `assets/js/auth.js` to only set `auth = window.firebase.auth()` when `window.firebase?.apps?.length` is truthy.
- Leave the existing `firestore` initialization guard in place so it only runs when an app exists.
- This is a minimal change focused on guarding auth initialization to avoid no-app access.

### Testing
- No automated tests were run for this change.
- Change is a small, static runtime guard applied to `initFirebase`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965b83e95c4832194f6f02ed87b4318)