### PR TITLE
Handle missing Firebase auth config and disable login UI

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -131,6 +131,11 @@
     transition: background .2s;
   }
 
+  #mainNav a[aria-disabled="true"] {
+    opacity: 0.55;
+    pointer-events: none;
+  }
+
   #mainNav a:hover,
   #mainNav button:hover {
     background: var(--fg);


### PR DESCRIPTION
### Motivation
- Prevent runtime errors and noisy warnings when Firebase configuration is not present by detecting missing config before initialization.  
- Avoid showing a nonfunctional login flow when auth is unavailable.  
- Surface a clear, accessible status message to users instead of allowing auth attempts to proceed.  

### Description
- Read `window.firebaseConfig` and validate required keys (`apiKey`, `authDomain`, `projectId`, `storageBucket`, `messagingSenderId`, `appId`), tracking availability in `firebaseAvailable`.  
- Update `initFirebase` to early-return when `firebaseAvailable` is false and only initialize `auth`/`firestore` when config is valid.  
- When Firebase is unavailable, disable the login UI by setting `aria-disabled` on the nav link, disabling the email input and submit button, intercepting clicks/submits to show `Firebase auth is unavailable. Check the site config.` and calling `updateAdminUi()` to update admin-only elements.  
- Add CSS for `#mainNav a[aria-disabled="true"]` to visually indicate a disabled login link.  

### Testing
- Launched a local static server with `python -m http.server` and used a Playwright script to open `index.html` and capture a screenshot to verify the disabled login state, which completed successfully.  
- No unit tests were added or modified for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965ba8330d0832192fc5074b17b8d53)