### PR TITLE
Fix markdown rendering in portfolio posts

### DIFF
--- a/assets/js/posts.js
+++ b/assets/js/posts.js
@@ -20,6 +20,15 @@ let portfolioStatus = null;
 let editPortfolioBtn = null;
 let searchInput = null;
 
+function renderPostContent(content) {
+  if (!postContentEl) return;
+  if (typeof window.marked?.parse === 'function') {
+    postContentEl.innerHTML = window.marked.parse(content);
+    return;
+  }
+  postContentEl.innerHTML = content;
+}
+
 function getYamlParser() {
   return globalThis.jsyaml;
 }
@@ -90,11 +99,7 @@ export async function openPost(url) {
       : null;
     const content = storedContent ?? (data.content || '');
     currentPost = { url, data, content };
-    if (typeof window.renderPostContent === 'function') {
-      window.renderPostContent(content);
-    } else if (postContentEl) {
-      postContentEl.innerHTML = content;
-    }
+    renderPostContent(content);
   } catch {
     currentPost = { url, data: null, content: '' };
     if (postContentEl) {


### PR DESCRIPTION
### Motivation

- Portfolio post markdown was rendering as raw text in the post modal instead of being parsed into HTML, making posts look broken.
- The code previously relied on an external `window.renderPostContent` hook which wasn't always present, so the content fell back to raw output.

### Description

- Added a local `renderPostContent` helper in `assets/js/posts.js` that parses content with `marked.parse` when available and otherwise falls back to raw content. 
- Replaced the conditional call to `window.renderPostContent` with the new local `renderPostContent` to simplify the rendering path. 
- Guarded rendering with `postContentEl` checks to avoid errors when the post container is not present. 
- Kept YAML parsing and post-loading logic unchanged, only updating how the post `content` is converted to HTML.

### Testing

- Started a local dev server with `python -m http.server` to serve the site, which launched successfully. 
- Performed an HTTP smoke test with `curl` which returned the site HTML successfully. 
- Attempted end-to-end UI checks with Playwright to open a portfolio entry and capture a screenshot, but the Playwright runs failed due to timeouts / missing selectors (navigation/screenshot did not succeed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965bc0f69888321bdefef4e7f1f84d2)