### PR TITLE
Offset anchored section scrolls to clear fixed header

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -35,6 +35,10 @@
   body {
     padding-top: var(--header-h);
   }
+
+  section[id] {
+    scroll-margin-top: calc(var(--header-h) + 16px);
+  }
   
   /* Typography */
   h1, h2, h3 {


### PR DESCRIPTION
### Motivation
- The fixed header (`--header-h`) was overlapping anchored section headings when navigating via links, hiding content beneath the header.
- Ensure clicked heading buttons / nav anchors land slightly below the header so the card/section is visible and not directly flush under the header.
- Improve UX when jumping to `#id` sections so content is readable without manual scrolling.

### Description
- Added a new rule in `styles.css`: `section[id] { scroll-margin-top: calc(var(--header-h) + 16px); }` to offset anchor scroll positions.
- Kept the existing `body { padding-top: var(--header-h); }` so page layout and header spacing remain unchanged.
- Change is a small, CSS-only update that adjusts the scroll landing position for any section with an `id` attribute.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965bd3b84588321868df888f49b29f4)