### PR TITLE
Allow disabled login link to remain clickable so modal can open

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -137,7 +137,7 @@
 
   #mainNav a[aria-disabled="true"] {
     opacity: 0.55;
-    pointer-events: none;
+    cursor: not-allowed;
   }
 
   #mainNav a:hover,


### PR DESCRIPTION
### Motivation
- The login link was greyed out and unresponsive because CSS was preventing pointer events, which blocked the click that should open the login modal.
- The site should indicate the disabled state while still allowing the UI to show a helpful message or modal when auth is unavailable.
- Preserve the visual disabled affordance without breaking the `openLoginModal` flow.

### Description
- Changed the `#mainNav a[aria-disabled="true"]` rule in `styles.css` to remove `pointer-events: none` and add `cursor: not-allowed`.
- This keeps the faded/disabled visual state while allowing click events to reach the element so JavaScript can open `#loginModal`.
- Only `styles.css` was modified.

### Testing
- Started a local server with `python -m http.server 8000` and served `index.html` successfully.
- Ran a Playwright script that loaded `/index.html` and captured a screenshot to `artifacts/login-button.png`, which completed successfully.
- No automated unit tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965bebd6d98832192e84014f103a570)