### PR TITLE
Fix login modal close behavior when auth is unavailable

### DIFF
--- a/assets/js/auth.js
+++ b/assets/js/auth.js
@@ -146,6 +146,18 @@ export function initAuth() {
   const loginEmail = $('#loginEmail');
   const loginCancel = $('#loginCancel');
 
+  if (loginModal) {
+    loginModal.addEventListener('click', event => {
+      if (event.target === loginModal) {
+        closeLoginModal();
+      }
+    });
+  }
+
+  if (loginCancel) {
+    loginCancel.addEventListener('click', closeLoginModal);
+  }
+
   if (!firebaseAvailable) {
     if (loginButton) {
       loginButton.setAttribute('aria-disabled', 'true');
@@ -180,18 +192,6 @@ export function initAuth() {
       }
       openLoginModal();
     });
-  }
-
-  if (loginModal) {
-    loginModal.addEventListener('click', event => {
-      if (event.target === loginModal) {
-        closeLoginModal();
-      }
-    });
-  }
-
-  if (loginCancel) {
-    loginCancel.addEventListener('click', closeLoginModal);
   }
 
   if (loginForm) {


### PR DESCRIPTION
### Motivation
- The admin login modal could not be dismissed when Firebase auth was unavailable, leaving the UI unusable after opening the dialog.
- The overlay and cancel handlers were only attached after the `firebaseAvailable` early return, so they were skipped when config/auth was missing.

### Description
- Attach the `loginModal` overlay click handler and the `loginCancel` click handler earlier in `initAuth` in `assets/js/auth.js` so they run regardless of `firebaseAvailable`.
- Remove the duplicate bindings that were previously added later in the function to avoid double-registration.
- Preserve existing `openLoginModal`/`closeLoginModal` behavior including `lockScroll`/`unlockScroll` and status updates.

### Testing
- No automated tests were added or executed for this change.
- The change is a small runtime wiring fix and the modified file `assets/js/auth.js` was committed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965bfe6e6ac8321bbe0967bd07a28bc)