### PR TITLE
Fix admin login modal close behavior when Firebase is unavailable

### DIFF
--- a/assets/js/auth.js
+++ b/assets/js/auth.js
@@ -146,6 +146,18 @@ export function initAuth() {
   const loginEmail = $('#loginEmail');
   const loginCancel = $('#loginCancel');
 
+  if (loginModal) {
+    loginModal.addEventListener('click', event => {
+      if (event.target === loginModal) {
+        closeLoginModal();
+      }
+    });
+  }
+
+  if (loginCancel) {
+    loginCancel.addEventListener('click', closeLoginModal);
+  }
+
   if (!firebaseAvailable) {
     if (loginButton) {
       loginButton.setAttribute('aria-disabled', 'true');
@@ -180,18 +192,6 @@ export function initAuth() {
       }
       openLoginModal();
     });
-  }
-
-  if (loginModal) {
-    loginModal.addEventListener('click', event => {
-      if (event.target === loginModal) {
-        closeLoginModal();
-      }
-    });
-  }
-
-  if (loginCancel) {
-    loginCancel.addEventListener('click', closeLoginModal);
   }
 
   if (loginForm) {


### PR DESCRIPTION
### Motivation
- The admin login modal could not be dismissed when Firebase auth was unavailable because overlay and cancel handlers were wired after an early return in `initAuth`.
- Users reported the modal blocking interaction with the page when auth was not configured, so the UI needs to remain dismissible regardless of auth state.

### Description
- Move overlay click handler and cancel-button handler to run at the start of `initAuth` so they are registered before the `firebaseAvailable` check in `assets/js/auth.js`.
- Remove the duplicate handlers that were previously registered later in the function to avoid redundant binding.
- Ensure `closeLoginModal` is available to the modal overlay and cancel button even when `firebaseAvailable` is `false`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965bfe6e6ac8321bbe0967bd07a28bc)