### PR TITLE
Initialize Firebase config in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -159,6 +159,17 @@
     <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-app-compat.js"></script>
     <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-auth-compat.js"></script>
     <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore-compat.js"></script>
+    <script>
+      window.firebaseConfig = {
+        apiKey: "AIzaSyBfLjtPI90S8WodG19OrEO6jmT-8lvqF1I",
+        authDomain: "joerice-6050b.firebaseapp.com",
+        projectId: "joerice-6050b",
+        storageBucket: "joerice-6050b.firebasestorage.app",
+        messagingSenderId: "653941248098",
+        appId: "1:653941248098:web:0c3ec15b49a312aacf813b",
+        measurementId: "G-SS56CMWCR7"
+      };
+    </script>
     <script type="module" src="assets/js/main.js"></script>
     <script>
       document.addEventListener("DOMContentLoaded", function() {


### PR DESCRIPTION
### Motivation
- Ensure the Firebase web app configuration is defined before the main client module loads so authentication and Firestore can initialize correctly.
- Prevent runtime errors in `assets/js/main.js` that expect Firebase configuration to be available on page load.
- Make the config easily accessible to client scripts via the global `window.firebaseConfig` object.

### Description
- Added an inline script to `index.html` that sets `window.firebaseConfig` with the Firebase project keys and identifiers.
- Placed the script immediately before the `assets/js/main.js` module import so the config is available when the module executes.
- Modified only the `index.html` file to inject the configuration into the page.

### Testing
- No automated tests were run for this static site change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966744bd01c8321a6ab7e1f3604f0d8)