### PR TITLE
Improve Firebase auth diagnostics and config fallback

### DIFF
--- a/index.html
+++ b/index.html
@@ -159,6 +159,17 @@
     <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-app-compat.js"></script>
     <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-auth-compat.js"></script>
     <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore-compat.js"></script>
+    <script>
+      window.firebaseConfig = {
+        apiKey: "AIzaSyBfLjtPI90S8WodG19OrEO6jmT-8lvqF1I",
+        authDomain: "joerice-6050b.firebaseapp.com",
+        projectId: "joerice-6050b",
+        storageBucket: "joerice-6050b.firebasestorage.app",
+        messagingSenderId: "653941248098",
+        appId: "1:653941248098:web:0c3ec15b49a312aacf813b",
+        measurementId: "G-SS56CMWCR7"
+      };
+    </script>
     <script type="module" src="assets/js/main.js"></script>
     <script>
       document.addEventListener("DOMContentLoaded", function() {


### PR DESCRIPTION
### Motivation
- Make it easier to diagnose why Firebase email-link sign-in fails by surfacing configuration and error details.
- Support alternative placement of Firebase config so client scripts can find it when loaded in different environments.
- Provide clearer, actionable status messages in the login UI when auth is unavailable.
- Prevent silent failures when `auth` is not initialized due to missing config or runtime issues.

### Description
- Read Firebase config from `window.firebaseConfig` or fall back to `window.FIREBASE_CONFIG` by using `window.firebaseConfig ?? window.FIREBASE_CONFIG`.
- Compute `missingFirebaseKeys` and derive `hasFirebaseConfig` from that list, and add `getFirebaseUnavailableMessage()` to report missing keys.
- Replace generic status messages with `getFirebaseUnavailableMessage()` where auth is unavailable and append `error.message` to user-facing messages in `sendLoginLink` and `completeEmailLinkSignIn`.
- Inject an inline `window.firebaseConfig` object into `index.html` so the client has the project keys available before `assets/js/main.js` runs.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966744bd01c8321a6ab7e1f3604f0d8)