### PR TITLE
Add portfolio post modal with local drafts and improve Firebase auth init

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,7 +50,7 @@
       <section class="portfolio" id="about">
         <div class="sectionHeader">
           <h2>Portfolio</h2>
-          <button class="editBtn" id="editPortfolioBtn" type="button">Edit</button>
+          <button class="editBtn" id="addPortfolioBtn" type="button" data-admin-only>Add Post</button>
         </div>
         <div class="portfolioStatus" id="portfolioStatus" hidden></div>
         <div class="subhead">Pinned</div>
@@ -154,11 +154,41 @@
         <p class="loginStatus" id="loginStatus" role="status" aria-live="polite"></p>
       </div>
     </div>
+    <div class="modal portfolioModal" id="portfolioModal" aria-hidden="true" role="dialog" aria-modal="true">
+      <div class="modalContent">
+        <div class="portfolioModalHeader">
+          <h3 id="portfolioModalTitle">Add portfolio post</h3>
+          <button class="portfolioCloseButton" id="portfolioCloseButton" type="button">Close</button>
+        </div>
+        <label class="portfolioField">Title
+          <input id="portfolioPostTitle" type="text" placeholder="Post title"/>
+        </label>
+        <label class="portfolioField portfolioBodyField">Post
+          <textarea id="portfolioPostBody" placeholder="Write your post here"></textarea>
+        </label>
+        <div class="portfolioActions">
+          <button class="portfolioSaveButton" id="portfolioSaveButton" type="button">Save</button>
+          <button class="portfolioDeleteButton" id="portfolioDeleteButton" type="button">Delete</button>
+        </div>
+        <p class="portfolioEditorStatus" id="portfolioEditorStatus" role="status" aria-live="polite"></p>
+      </div>
+    </div>
     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/js-yaml@4.1.0/dist/js-yaml.min.js"></script>
     <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-app-compat.js"></script>
     <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-auth-compat.js"></script>
     <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore-compat.js"></script>
+    <script>
+      window.firebaseConfig = {
+        apiKey: "AIzaSyBfLjtPI90S8WodG19OrEO6jmT-8lvqF1I",
+        authDomain: "joerice-6050b.firebaseapp.com",
+        projectId: "joerice-6050b",
+        storageBucket: "joerice-6050b.firebasestorage.app",
+        messagingSenderId: "653941248098",
+        appId: "1:653941248098:web:0c3ec15b49a312aacf813b",
+        measurementId: "G-SS56CMWCR7"
+      };
+    </script>
     <script type="module" src="assets/js/main.js"></script>
     <script>
       document.addEventListener("DOMContentLoaded", function() {

--- a/styles.css
+++ b/styles.css
@@ -900,6 +900,88 @@
     min-height: 1.2rem;
     color: var(--blue);
   }
+
+  .portfolioModal .modalContent {
+    max-width: 760px;
+    width: min(92vw, 760px);
+    text-align: left;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    min-height: 420px;
+  }
+
+  .portfolioModalHeader {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1rem;
+  }
+
+  .portfolioModalHeader h3 {
+    margin: 0;
+  }
+
+  .portfolioCloseButton {
+    border: 1px solid var(--border);
+    padding: .4rem .8rem;
+    background: transparent;
+    font-family: var(--fontHead);
+    cursor: pointer;
+  }
+
+  .portfolioField {
+    display: grid;
+    gap: .35rem;
+    font-size: .95rem;
+  }
+
+  .portfolioField input,
+  .portfolioField textarea {
+    border: 1px solid var(--border);
+    padding: .6rem;
+    font-family: var(--font);
+    width: 100%;
+    box-sizing: border-box;
+  }
+
+  .portfolioBodyField {
+    flex: 1;
+  }
+
+  .portfolioBodyField textarea {
+    flex: 1;
+    min-height: 240px;
+    resize: vertical;
+  }
+
+  .portfolioActions {
+    display: flex;
+    gap: .6rem;
+    flex-wrap: wrap;
+  }
+
+  .portfolioSaveButton,
+  .portfolioDeleteButton {
+    border: 1px solid var(--border);
+    padding: .5rem 1rem;
+    font-family: var(--fontHead);
+    cursor: pointer;
+  }
+
+  .portfolioSaveButton {
+    background: var(--green);
+    color: #fff;
+  }
+
+  .portfolioDeleteButton {
+    background: transparent;
+  }
+
+  .portfolioEditorStatus {
+    min-height: 1.2rem;
+    margin: 0;
+  }
   
   /* Links section */
   .links h2 {


### PR DESCRIPTION
### Motivation
- Replace the fragile in-place portfolio edit workflow with a simple admin-only "Add Post" flow and a clean editor modal for creating new posts.  
- Keep preloaded posts read-only while allowing admins to create, edit, and delete only newly created posts stored locally.  
- Surface clearer Firebase auth availability messages and retry initialization when the user interacts with auth UI.  
- Provide a polished UI for the editor (full-width title, large textarea, save/delete actions) that is production-ready for a static site.

### Description
- Replaced the portfolio edit control in `index.html` with an admin-only `Add Post` button (`#addPortfolioBtn`) and added the portfolio editor modal markup (`#portfolioModal`, title input, body textarea, `Save` and `Delete` buttons).  
- Added modal styling to `styles.css` for the editor layout, textarea sizing, action buttons, and status messages.  
- Implemented local-draft support and editor behavior in `assets/js/posts.js` including `localPosts` storage via `localStorage` (`portfolioLocalPosts`), functions `loadLocalPosts`, `saveLocalPosts`, `syncLocalPostsToNotes`, `openPortfolioEditor`, and `closePortfolioEditor`, and wired save/delete handlers so only local posts are editable/deletable.  
- Improved Firebase/auth handling in `assets/js/auth.js` by lazily reading `window.firebaseConfig`, computing `missingFirebaseKeys`, adding `initFirebase()` retries, and introducing `getFirebaseUnavailableMessage()` to provide clearer user-facing status text when auth is unavailable.

### Testing
- Launched a local static server with `python -m http.server` and used an automated Playwright script to open the page, show the modal, and capture a screenshot, and the script completed successfully.  
- Verified the editor modal appears and fields are focusable in the automated run, indicating the DOM wiring and styles loaded correctly.  
- No unit tests were added for these UI changes.  
- Manual smoke tests for creating/editing/deleting local drafts were exercised via the modal during development (not automated).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966744bd01c8321a6ab7e1f3604f0d8)