### PR TITLE
Add stock content toggle for posts, quotes, and gallery

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -3,12 +3,14 @@ import { initContact } from './contact.js';
 import { initGallery } from './gallery.js';
 import { initPosts } from './posts.js';
 import { initQuotes } from './quotes.js';
+import { initStockContentToggle } from './stock.js';
 import { initTooltips } from './tooltips.js';
 import { initLayout } from './ui/layout.js';
 
 document.addEventListener('DOMContentLoaded', () => {
   initLayout();
   initAuth();
+  initStockContentToggle();
   initPosts();
   initQuotes();
   initGallery();

--- a/assets/js/stock.js
+++ b/assets/js/stock.js
@@ -1,0 +1,33 @@
+import { $ } from './dom.js';
+
+const stockContentStorageKey = 'showStockContent';
+
+export function isStockContentEnabled() {
+  const stored = window.localStorage.getItem(stockContentStorageKey);
+  return stored !== 'false';
+}
+
+function setStockContentEnabled(enabled) {
+  window.localStorage.setItem(stockContentStorageKey, enabled ? 'true' : 'false');
+  window.dispatchEvent(
+    new CustomEvent('stockcontentchange', {
+      detail: { enabled },
+    }),
+  );
+}
+
+export function onStockContentChange(handler) {
+  window.addEventListener('stockcontentchange', (event) => {
+    const enabled = event.detail?.enabled ?? isStockContentEnabled();
+    handler(enabled);
+  });
+}
+
+export function initStockContentToggle() {
+  const toggle = $('#stockContentToggle');
+  if (!toggle) return;
+  toggle.checked = isStockContentEnabled();
+  toggle.addEventListener('change', (event) => {
+    setStockContentEnabled(event.target.checked);
+  });
+}

--- a/index.html
+++ b/index.html
@@ -51,7 +51,13 @@
           </div>
         </div>
       </section>
-      <div class="search"><input id="q" type="search" placeholder="Search posts and notes..."/></div>
+      <div class="search">
+        <input id="q" type="search" placeholder="Search posts and notes..."/>
+        <label class="stockToggle" for="stockContentToggle">
+          <input id="stockContentToggle" type="checkbox" checked/>
+          <span>Show Stock Content</span>
+        </label>
+      </div>
       <section class="portfolio" id="about">
         <div class="sectionHeader">
           <h2>Portfolio</h2>

--- a/styles.css
+++ b/styles.css
@@ -291,6 +291,9 @@ header {
 /* Search */
 .search {
   margin-block: var(--space);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
 }
 
 #q {
@@ -304,6 +307,20 @@ header {
 
 #q::placeholder {
   color: #e5e5e5;
+}
+
+.stockToggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  font-size: 0.95rem;
+  color: #fff;
+}
+
+.stockToggle input {
+  accent-color: var(--yellow);
+  width: 1rem;
+  height: 1rem;
 }
 
 /* Sections */


### PR DESCRIPTION
### Motivation
- Provide a single, persistent toggle that lets the site owner hide or show stock content (GitHub YAML posts, YAML quotes, and fallback/picsum gallery) across the public site.

### Description
- Add a UI control: a `Show Stock Content` checkbox next to the search input in `index.html` with supporting styles in `styles.css` and markup id `stockContentToggle`.
- Add a small feature module `assets/js/stock.js` that exposes `isStockContentEnabled`, `onStockContentChange`, and `initStockContentToggle` and persists the preference to `localStorage` while broadcasting changes via a custom event.
- Wire the toggle into app startup by calling `initStockContentToggle()` from `assets/js/main.js` and update `assets/js/quotes.js`, `assets/js/posts.js`, and `assets/js/gallery.js` so each loader respects `isStockContentEnabled()` and refreshes when `onStockContentChange` triggers; gallery code was updated to return no stock/fallback slides when disabled and to provide `refreshGalleryContent()` and `clearSlideshow()` helpers, quotes now conditionally loads YAML and can stop the carousel, and posts skip YAML loading when disabled with a `refreshStockContent()` helper.

### Testing
- Ran the project linter via `npm run lint:biome`, which fixed style issues and completed successfully.
- Performed a local smoke test by serving the site with `python -m http.server 8000` and capturing a screenshot with Playwright to verify the toggle renders and the UI loads; the screenshot was produced successfully.
- No automated unit tests were added or run beyond the lint and the UI smoke check, and both checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d51bf4b888321a51c0e203006c7da)