### PR TITLE
Add reCAPTCHA v3 to Formspree integration

### DIFF
--- a/assets/js/contact.js
+++ b/assets/js/contact.js
@@ -34,6 +34,10 @@ export function initContact() {
       e.preventDefault();
       const fd = new FormData(e.target);
       try {
+        // Get reCAPTCHA token
+        const token = await grecaptcha.execute('6LcYpE4sAAAAALOW_7HWe81eUCnFkGFu-e8dAW_S', { action: 'submit' });
+        fd.append('g-recaptcha-response', token);
+
         await fetch('https://formspree.io/f/xovqpvdv', {
           method: 'POST',
           body: fd,

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <!-- Content Security Policy for XSS protection. For better performance and readability, 
          consider moving this to an HTTP header if you have server-side control. 
          See SECURITY.md for details. -->
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://www.gstatic.com https://formspree.io; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdnjs.cloudflare.com; font-src 'self' https://fonts.gstatic.com https://cdnjs.cloudflare.com; img-src 'self' https: data: blob:; connect-src 'self' https://formspree.io https://firebasestorage.googleapis.com https://firestore.googleapis.com https://identitytoolkit.googleapis.com https://securetoken.googleapis.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self' https://formspree.io;"/>
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://www.gstatic.com https://www.google.com https://formspree.io; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdnjs.cloudflare.com; font-src 'self' https://fonts.gstatic.com https://cdnjs.cloudflare.com; img-src 'self' https: data: blob:; connect-src 'self' https://formspree.io https://www.google.com https://firebasestorage.googleapis.com https://firestore.googleapis.com https://identitytoolkit.googleapis.com https://securetoken.googleapis.com; frame-src https://www.google.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self' https://formspree.io;"/>
     <title>Joe Rice · Portfolio</title>
     <link rel="preconnect" href="https://fonts.googleapis.com"/>
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
@@ -234,6 +234,7 @@
         measurementId: "G-SS56CMWCR7"
       };
     </script>
+    <script src="https://www.google.com/recaptcha/api.js?render=6LcYpE4sAAAAALOW_7HWe81eUCnFkGFu-e8dAW_S"></script>
     <script type="module" src="assets/js/main.js"></script>
     <script>
       document.getElementById("year").textContent = new Date().getFullYear();


### PR DESCRIPTION
- Updated Content Security Policy to allow Google reCAPTCHA domains
- Added reCAPTCHA v3 script with site key to HTML
- Modified contact form submission to generate and include reCAPTCHA token
- Token is appended to form data before submission to Formspree