### PR TITLE
Add local Hire page with flip-card services

### DIFF
--- a/assets/js/github-content.js
+++ b/assets/js/github-content.js
@@ -21,7 +21,9 @@ export function isGithubContentEnabled() {
 export function setGithubContentEnabled(enabled) {
   window.localStorage.setItem(STORAGE_KEY, String(enabled));
   // Notify all registered callbacks
-  changeCallbacks.forEach((callback) => callback(enabled));
+  changeCallbacks.forEach((callback) => {
+    callback(enabled);
+  });
 }
 
 /**

--- a/hire.html
+++ b/hire.html
@@ -1,0 +1,225 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
+    <!-- Content Security Policy for XSS protection. For better performance and readability, 
+         consider moving this to an HTTP header if you have server-side control. 
+         See SECURITY.md for details. -->
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://www.gstatic.com https://www.google.com https://formspree.io; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdnjs.cloudflare.com; font-src 'self' https://fonts.gstatic.com https://cdnjs.cloudflare.com; img-src 'self' https: data: blob:; connect-src 'self' https://formspree.io https://www.google.com https://firebasestorage.googleapis.com https://firestore.googleapis.com https://identitytoolkit.googleapis.com https://securetoken.googleapis.com; frame-src https://www.google.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self' https://formspree.io;"/>
+    <title>Joe Rice · Hire Me</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com"/>
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+    <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600&family=Bebas+Neue&family=Fira+Code&display=swap" rel="stylesheet"/>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css"/>
+    <link rel="stylesheet" href="styles.css"/>
+  </head>
+  <body>
+    <header class="siteHeader">
+      <div class="brand"><a href="https://joerice.me/">joerice.me</a></div>
+      <button class="menuToggle" aria-label="Menu"><span></span><span></span><span></span></button>
+      <nav id="mainNav">
+        <a href="https://joerice.me/">Home</a>
+        <a href="hire.html" aria-current="page">Hire Me</a>
+        <a href="https://joerice.me/#about">Portfolio</a>
+        <a href="https://joerice.me/#contact">Contact Me</a>
+        <a href="https://joerice.me/#quotes">Quotes</a>
+        <a href="https://joerice.me/#links">Useful Links</a>
+        <a class="navButton" id="loginButton" href="#loginModal">Login</a>
+      </nav>
+    </header>
+    <main class="max">
+      <section class="hero">
+        <img class="pic" src="assets/images/pictures/profile.jpg" alt="Joe Rice"/>
+        <div class="intro">
+          <h1>Hire Joe</h1>
+          <p>I help individuals and small teams ship clean, thoughtful digital experiences. Tap any card to flip it and see what each service includes.</p>
+          <div class="social">
+            <a href="https://pin.it/7ikA1HZ4o" target="_blank" aria-label="Pinterest"><i class="fab fa-pinterest"></i></a>
+            <a href="https://www.instagram.com/garbledhamster/" target="_blank" aria-label="Instagram"><i class="fab fa-instagram"></i></a>
+            <a href="https://www.facebook.com/garbledhamster/" target="_blank" aria-label="Facebook"><i class="fab fa-facebook"></i></a>
+            <a href="https://buymeacoffee.com/garbledhamster" target="_blank" aria-label="Buy Me A Coffee"><i class="fas fa-mug-hot"></i></a>
+            <a href="https://github.com/garbledhamster" target="_blank" aria-label="GitHub"><i class="fab fa-github"></i></a>
+            <a href="https://www.upwork.com/freelancers/~016021fb4f5ed4ff13?mp_source=share" target="_blank" aria-label="Upwork"><i class="fab fa-upwork"></i></a>
+            <a href="https://fiverr.com/" target="_blank" aria-label="Fiverr"><i class="fab fa-fiverr"></i></a>
+            <a href="https://www.etsy.com/shop/zettelkastenshop" target="_blank" aria-label="Etsy"><i class="fab fa-etsy"></i></a>
+          </div>
+        </div>
+      </section>
+      <section class="services" id="services">
+        <div class="sectionHeader">
+          <h2>Services</h2>
+          <span class="servicesNote">Tap or click a card to flip it.</span>
+        </div>
+        <div class="serviceGrid">
+          <label class="serviceCard">
+            <input class="serviceToggle" type="checkbox" aria-label="Flip Web Site card"/>
+            <span class="serviceCardInner">
+              <span class="serviceCardFace serviceCardFront">
+                <h3>Web Site</h3>
+                <p>Marketing sites, portfolios, and landing pages that load fast and look sharp.</p>
+                <span class="serviceCardHint">Tap to flip</span>
+              </span>
+              <span class="serviceCardFace serviceCardBack">
+                <h3>Highlights</h3>
+                <ul>
+                  <li>Discovery + sitemap</li>
+                  <li>Responsive layout</li>
+                  <li>Performance + SEO basics</li>
+                </ul>
+              </span>
+            </span>
+          </label>
+          <label class="serviceCard">
+            <input class="serviceToggle" type="checkbox" aria-label="Flip Web App card"/>
+            <span class="serviceCardInner">
+              <span class="serviceCardFace serviceCardFront">
+                <h3>Web App</h3>
+                <p>Interactive products with clean UI, scalable structure, and thoughtful UX.</p>
+                <span class="serviceCardHint">Tap to flip</span>
+              </span>
+              <span class="serviceCardFace serviceCardBack">
+                <h3>Highlights</h3>
+                <ul>
+                  <li>Product planning</li>
+                  <li>UI/UX flows</li>
+                  <li>Deployment guidance</li>
+                </ul>
+              </span>
+            </span>
+          </label>
+          <label class="serviceCard">
+            <input class="serviceToggle" type="checkbox" aria-label="Flip IT Services card"/>
+            <span class="serviceCardInner">
+              <span class="serviceCardFace serviceCardFront">
+                <h3>IT Services</h3>
+                <p>Troubleshooting, device setup, and small-business tech support.</p>
+                <span class="serviceCardHint">Tap to flip</span>
+              </span>
+              <span class="serviceCardFace serviceCardBack">
+                <h3>Highlights</h3>
+                <ul>
+                  <li>Home/office networks</li>
+                  <li>Hardware diagnostics</li>
+                  <li>Security checkups</li>
+                </ul>
+              </span>
+            </span>
+          </label>
+          <label class="serviceCard">
+            <input class="serviceToggle" type="checkbox" aria-label="Flip Knowledge Mgmt card"/>
+            <span class="serviceCardInner">
+              <span class="serviceCardFace serviceCardFront">
+                <h3>Knowledge Mgmt</h3>
+                <p>Note systems and workflows to capture, organize, and retrieve ideas.</p>
+                <span class="serviceCardHint">Tap to flip</span>
+              </span>
+              <span class="serviceCardFace serviceCardBack">
+                <h3>Highlights</h3>
+                <ul>
+                  <li>Zettelkasten setup</li>
+                  <li>Searchable structure</li>
+                  <li>Training + habits</li>
+                </ul>
+              </span>
+            </span>
+          </label>
+          <label class="serviceCard">
+            <input class="serviceToggle" type="checkbox" aria-label="Flip Logo Design card"/>
+            <span class="serviceCardInner">
+              <span class="serviceCardFace serviceCardFront">
+                <h3>Logo Design</h3>
+                <p>Simple, bold marks with usable brand assets for print and digital.</p>
+                <span class="serviceCardHint">Tap to flip</span>
+              </span>
+              <span class="serviceCardFace serviceCardBack">
+                <h3>Highlights</h3>
+                <ul>
+                  <li>Concept sketches</li>
+                  <li>Vector delivery</li>
+                  <li>Usage guidance</li>
+                </ul>
+              </span>
+            </span>
+          </label>
+          <label class="serviceCard">
+            <input class="serviceToggle" type="checkbox" aria-label="Flip Resume Writing card"/>
+            <span class="serviceCardInner">
+              <span class="serviceCardFace serviceCardFront">
+                <h3>Resume Writing</h3>
+                <p>Recruiter-ready resumes tuned for clarity, impact, and outcomes.</p>
+                <span class="serviceCardHint">Tap to flip</span>
+              </span>
+              <span class="serviceCardFace serviceCardBack">
+                <h3>Highlights</h3>
+                <ul>
+                  <li>Story arc</li>
+                  <li>ATS-friendly format</li>
+                  <li>LinkedIn polish</li>
+                </ul>
+              </span>
+            </span>
+          </label>
+          <label class="serviceCard">
+            <input class="serviceToggle" type="checkbox" aria-label="Flip AI Coaching card"/>
+            <span class="serviceCardInner">
+              <span class="serviceCardFace serviceCardFront">
+                <h3>AI Coaching</h3>
+                <p>Hands-on coaching to use AI tools for real work and daily workflows.</p>
+                <span class="serviceCardHint">Tap to flip</span>
+              </span>
+              <span class="serviceCardFace serviceCardBack">
+                <h3>Highlights</h3>
+                <ul>
+                  <li>Prompt patterns</li>
+                  <li>Workflow automation</li>
+                  <li>Ethics + guardrails</li>
+                </ul>
+              </span>
+            </span>
+          </label>
+        </div>
+      </section>
+    </main>
+    <footer>© <span id="year"></span> Joe Rice. All rights reserved.</footer>
+    <div class="modal loginModal" id="loginModal" aria-hidden="true" role="dialog" aria-modal="true">
+      <div class="modalContent">
+        <h3>Admin login</h3>
+        <p>Enter your email to receive a sign-in link.</p>
+        <form id="loginForm">
+          <label for="loginEmail">Email</label>
+          <input id="loginEmail" type="email" autocomplete="email" required/>
+          <div class="loginActions">
+            <button class="loginSendButton" type="submit">Send login link</button>
+            <a class="loginCancelButton" id="loginCancel" href="#" role="button">Cancel</a>
+          </div>
+        </form>
+        <label class="loginFieldCheckbox" data-admin-only hidden>
+          <input id="showGithubContent" type="checkbox" checked/>
+          <span>Show GitHub Content</span>
+        </label>
+        <button class="loginLogoutButton" id="loginLogoutButton" type="button" data-admin-only hidden>Logout</button>
+        <p class="loginStatus" id="loginStatus" role="status" aria-live="polite"></p>
+      </div>
+    </div>
+    <script>
+      window.firebaseConfig = {
+        apiKey: "AIzaSyBfLjtPI90S8WodG19OrEO6jmT-8lvqF1I",
+        authDomain: "joerice-6050b.firebaseapp.com",
+        projectId: "joerice-6050b",
+        storageBucket: "joerice-6050b.firebasestorage.app",
+        messagingSenderId: "653941248098",
+        appId: "1:653941248098:web:0c3ec15b49a312aacf813b",
+        measurementId: "G-SS56CMWCR7"
+      };
+    </script>
+    <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-app-compat.js"></script>
+    <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-auth-compat.js"></script>
+    <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore-compat.js"></script>
+    <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-storage-compat.js"></script>
+    <script type="module" src="assets/js/main.js"></script>
+    <script>
+      document.getElementById('year').textContent = new Date().getFullYear();
+    </script>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
       <button class="menuToggle" aria-label="Menu"><span></span><span></span><span></span></button>
       <nav id="mainNav">
         <a href="https://joerice.me/">Home</a>
-        <a href="https://hire.joerice.me">Hire Me</a>
+        <a href="hire.html">Hire Me</a>
         <a href="https://joerice.me/#about">Portfolio</a>
         <a href="https://joerice.me/#contact">Contact Me</a>
         <a href="https://joerice.me/#quotes">Quotes</a>

--- a/styles.css
+++ b/styles.css
@@ -65,6 +65,13 @@ h3 {
   font-size: clamp(1.2rem, 3vw, 1.5rem);
 }
 
+.subhead {
+  font-family: var(--fontHead);
+  margin: 0.6rem 0 0.4rem;
+  font-size: 1rem;
+  text-decoration: underline;
+}
+
 .sectionHeader {
   display: flex;
   align-items: center;
@@ -311,6 +318,7 @@ header {
 .gallery,
 .quotes,
 .contact,
+.services,
 .links {
   border: 1px solid var(--border);
   margin-block: var(--space);
@@ -346,11 +354,87 @@ header {
   margin-bottom: clamp(40px, 8vw, 80px);
 }
 
-.subhead {
-  font-family: var(--fontHead);
-  margin: 0.6rem 0 0.4rem;
-  font-size: 1rem;
-  text-decoration: underline;
+.services {
+  background: var(--yellow);
+  color: var(--fg);
+}
+
+.servicesNote {
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+.serviceGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: var(--space);
+}
+
+.serviceCard {
+  position: relative;
+  display: block;
+  cursor: pointer;
+  perspective: 1200px;
+}
+
+.serviceToggle {
+  position: absolute;
+  opacity: 0;
+  inset: 0;
+  cursor: pointer;
+}
+
+.serviceCardInner {
+  position: relative;
+  min-height: 220px;
+  transform-style: preserve-3d;
+  transition: transform 0.6s ease;
+}
+
+.serviceCardFace {
+  position: absolute;
+  inset: 0;
+  border: 1px solid var(--border);
+  background: var(--bg);
+  color: var(--fg);
+  padding: 1.2rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 0.6rem;
+  backface-visibility: hidden;
+}
+
+.serviceCardFront p {
+  font-size: 0.98rem;
+}
+
+.serviceCardBack {
+  background: var(--fg);
+  color: var(--bg);
+  transform: rotateY(180deg);
+}
+
+.serviceCardBack ul {
+  list-style: disc;
+  padding-left: 1.1rem;
+  display: grid;
+  gap: 0.35rem;
+}
+
+.serviceCardHint {
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.serviceCard:focus-within .serviceCardInner {
+  box-shadow: 0 0 0 3px var(--fg);
+}
+
+.serviceToggle:checked + .serviceCardInner {
+  transform: rotateY(180deg);
 }
 
 .sectionHeader {


### PR DESCRIPTION
### Motivation
- Provide a local, consistent “Hire Me” page that fits the existing site layout so visitors can see offered services without leaving the site.
- Present the service categories as compact, mobile-friendly cards that flip to reveal highlights for an immediate, scannable view.

### Description
- Add a new `hire.html` that mirrors the site header/nav/structure from `index.html` and contains a `services` section with seven flip-card service entries (Web Site, Web App, IT Services, Knowledge Mgmt, Logo Design, Resume Writing, AI Coaching).
- Update the main navigation on the homepage so the “Hire Me” link points to the local `hire.html` page (`index.html` link changed to `hire.html`).
- Add CSS rules to `styles.css` to theme the `.services` section and implement the flip-card UI (`.serviceGrid`, `.serviceCard`, `.serviceCardInner`, `.serviceCardFace`, etc.) using the same design tokens and layout conventions used site-wide.
- Make a small JS formatting change in `assets/js/github-content.js` (wrap the `forEach` callback body) to satisfy linting rules triggered by the project's pre-commit checks.

### Testing
- Ran the project linter/fixes with `biome check --write .` and the linter completed successfully after the small JS change.
- Performed an automated smoke render by serving the site with `python -m http.server 8000` and capturing a screenshot of `http://127.0.0.1:8000/hire.html` using a Playwright script; the page rendered and the screenshot was produced successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978130a57f483218e8bcf8b7ab108ed)