### PR TITLE
Fix hire page service card layout

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -394,6 +394,8 @@ header {
 
 .serviceCardInner {
   position: relative;
+  display: block;
+  width: 100%;
   height: var(--service-card-height);
   transform-style: preserve-3d;
   -webkit-transform-style: preserve-3d;


### PR DESCRIPTION
### Motivation
- Service cards on the hire page were rendering with misaligned/broken faces because the inner flippable wrapper did not behave as a full-width block, causing size and layout issues.

### Description
- Update `.serviceCardInner` in `styles.css` to include `display: block;` and `width: 100%;` so the front/back faces size and flip correctly.

### Testing
- Ran the formatter/lint check with `biome check --write .` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69836de539708321bd0d9411427f2d16)