### PR TITLE
Refactor profile section into persistent app shell component

### DIFF
--- a/assets/js/components/profile.js
+++ b/assets/js/components/profile.js
@@ -1,0 +1,63 @@
+/**
+ * @file components/profile.js
+ * @description Persistent profile section rendered once in the app shell.
+ *
+ * Contains the profile photo, social links, and a description paragraph
+ * whose text updates automatically whenever the active route changes.
+ */
+
+import { $ } from '../core/dom.js';
+
+const socialLinks = [
+  { href: 'https://pin.it/7ikA1HZ4o', icon: 'fab fa-pinterest', label: 'Pinterest' },
+  { href: 'https://www.instagram.com/garbledhamster/', icon: 'fab fa-instagram', label: 'Instagram' },
+  { href: 'https://www.facebook.com/garbledhamster/', icon: 'fab fa-facebook', label: 'Facebook' },
+  { href: 'https://buymeacoffee.com/garbledhamster', icon: 'fas fa-mug-hot', label: 'Buy Me A Coffee' },
+  { href: 'https://github.com/garbledhamster', icon: 'fab fa-github', label: 'GitHub' },
+  { href: 'https://www.upwork.com/freelancers/~016021fb4f5ed4ff13?mp_source=share', icon: 'fab fa-upwork', label: 'Upwork' },
+  { href: 'https://fiverr.com/', icon: 'fab fa-fiverr', label: 'Fiverr' },
+  { href: 'https://www.etsy.com/shop/zettelkastenshop', icon: 'fab fa-etsy', label: 'Etsy' },
+];
+
+const pageDescriptions = {
+  '/home':      "I'm a husband, father, IT generalist, and entrepreneur at heart. I love sharing knowledge and have over a decade of experience in IT. If you're looking to connect with someone who's down to earth, open minded yet skeptical, and passionate about self improvement — use the nav to explore or get in touch.",
+  '/portfolio': 'A collection of my posts, notes, and projects. Browse through my work or search for something specific.',
+  '/gallery':   'Photos and images I\'ve collected. Flip through the slideshow to see what catches your eye.',
+  '/hire':      'I help individuals and small teams ship clean, thoughtful digital experiences. Tap any card below to see what each service includes.',
+  '/quotes':    'Quotes that have shaped how I think and work. A new one rotates in every few seconds.',
+  '/contact':   'Have a question or want to work together? Fill out the form below and I\'ll get back to you within 24 hours.',
+  '/links':     'A curated collection of resources I return to regularly — bookmarked for a reason.',
+};
+
+/**
+ * Get profile section HTML template.
+ * The description paragraph starts empty; updateProfileDescription sets it
+ * on the first route notification before the browser paints.
+ * @returns {string} Profile section HTML
+ */
+export function getProfileTemplate() {
+  const socialLinksHtml = socialLinks
+    .map(link => `<a href="${link.href}" target="_blank" aria-label="${link.label}"><i class="${link.icon}"></i></a>`)
+    .join('');
+
+  return `
+    <section class="hero max">
+      <img class="pic" src="assets/images/pictures/profile.jpg" alt="Joe Rice"/>
+      <div class="social">
+        ${socialLinksHtml}
+      </div>
+      <p class="profileDesc" id="profileDesc"></p>
+    </section>
+  `;
+}
+
+/**
+ * Swap the profile description text for the given route.
+ * Falls back to the home description if the route has no entry.
+ * @param {string} route - Current route path (e.g. '/portfolio')
+ */
+export function updateProfileDescription(route) {
+  const desc = $('#profileDesc');
+  if (!desc) return;
+  desc.textContent = pageDescriptions[route] || pageDescriptions['/home'];
+}

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -9,6 +9,7 @@
 import { ready } from './core/dom.js';
 import { initRouter, registerRoutes, setDefaultRoute, getCurrentRoute, onRouteChange } from './core/router.js';
 import { initHeader, getHeaderTemplate } from './components/header.js';
+import { getProfileTemplate, updateProfileDescription } from './components/profile.js';
 import { initModals } from './components/modal.js';
 import { initAuth, updateAdminUi } from './services/auth.js';
 import { initFirebase } from './services/firebase.js';
@@ -155,9 +156,10 @@ async function initApp() {
     return;
   }
 
-  // Render app shell (header + main content area + footer + modals)
+  // Render app shell (header + profile + main content area + footer + modals)
   app.innerHTML = `
     ${getHeaderTemplate()}
+    ${getProfileTemplate()}
     <main class="max" id="mainContent"></main>
     <footer>© <span id="year">${new Date().getFullYear()}</span> Joe Rice. All rights reserved.</footer>
     ${getLoginModalTemplate()}
@@ -174,9 +176,10 @@ async function initApp() {
   setDefaultRoute('/home');
   initRouter();
 
-  // Update admin UI on route change
-  onRouteChange(() => {
+  // Update admin UI and profile description on route change
+  onRouteChange((route) => {
     updateAdminUi();
+    updateProfileDescription(route);
   });
 
   // Mark page as loaded

--- a/assets/js/pages/hire.js
+++ b/assets/js/pages/hire.js
@@ -57,41 +57,13 @@ const services = [
 ];
 
 /**
- * Social media links
- */
-const socialLinks = [
-  { href: 'https://pin.it/7ikA1HZ4o', icon: 'fab fa-pinterest', label: 'Pinterest' },
-  { href: 'https://www.instagram.com/garbledhamster/', icon: 'fab fa-instagram', label: 'Instagram' },
-  { href: 'https://www.facebook.com/garbledhamster/', icon: 'fab fa-facebook', label: 'Facebook' },
-  { href: 'https://buymeacoffee.com/garbledhamster', icon: 'fas fa-mug-hot', label: 'Buy Me A Coffee' },
-  { href: 'https://github.com/garbledhamster', icon: 'fab fa-github', label: 'GitHub' },
-  { href: 'https://www.upwork.com/freelancers/~016021fb4f5ed4ff13?mp_source=share', icon: 'fab fa-upwork', label: 'Upwork' },
-  { href: 'https://fiverr.com/', icon: 'fab fa-fiverr', label: 'Fiverr' },
-  { href: 'https://www.etsy.com/shop/zettelkastenshop', icon: 'fab fa-etsy', label: 'Etsy' },
-];
-
-/**
  * Get hire page HTML template
  * @returns {string} Hire page HTML
  */
 export function getHireTemplate() {
-  const socialLinksHtml = socialLinks
-    .map(link => `<a href="${link.href}" target="_blank" aria-label="${link.label}"><i class="${link.icon}"></i></a>`)
-    .join('');
-
   const serviceCardsHtml = services.map(service => createServiceCard(service)).join('');
 
   return `
-    <section class="hero">
-      <img class="pic" src="assets/images/pictures/profile.jpg" alt="Joe Rice"/>
-      <div class="intro">
-        <h1>Hire Joe</h1>
-        <p>I help individuals and small teams ship clean, thoughtful digital experiences. Tap any card to flip it and see what each service includes.</p>
-        <div class="social">
-          ${socialLinksHtml}
-        </div>
-      </div>
-    </section>
     <section class="services" id="servicesSection">
       <div class="sectionHeader">
         <h2>Services</h2>

--- a/assets/js/pages/home.js
+++ b/assets/js/pages/home.js
@@ -2,72 +2,27 @@
  * @file pages/home.js
  * @description Home page module
  *
- * Renders the home page with profile photo and intro text
- * This is the landing page - simple and focused
+ * The profile photo, social links, and landing description are rendered
+ * by the persistent profile component in the app shell.  This page has
+ * no additional content to render.
  */
 
 import { $ } from '../core/dom.js';
-
-/**
- * Social media links configuration
- */
-const socialLinks = [
-  { href: 'https://pin.it/7ikA1HZ4o', icon: 'fab fa-pinterest', label: 'Pinterest' },
-  { href: 'https://www.instagram.com/garbledhamster/', icon: 'fab fa-instagram', label: 'Instagram' },
-  { href: 'https://www.facebook.com/garbledhamster/', icon: 'fab fa-facebook', label: 'Facebook' },
-  { href: 'https://buymeacoffee.com/garbledhamster', icon: 'fas fa-mug-hot', label: 'Buy Me A Coffee' },
-  { href: 'https://github.com/garbledhamster', icon: 'fab fa-github', label: 'GitHub' },
-  { href: 'https://www.upwork.com/freelancers/~016021fb4f5ed4ff13?mp_source=share', icon: 'fab fa-upwork', label: 'Upwork' },
-  { href: 'https://fiverr.com/', icon: 'fab fa-fiverr', label: 'Fiverr' },
-  { href: 'https://www.etsy.com/shop/zettelkastenshop', icon: 'fab fa-etsy', label: 'Etsy' },
-];
-
-/**
- * Get home page HTML template
- * @returns {string} Home page HTML
- */
-export function getHomeTemplate() {
-  const socialLinksHtml = socialLinks
-    .map(link => `<a href="${link.href}" target="_blank" aria-label="${link.label}"><i class="${link.icon}"></i></a>`)
-    .join('');
-
-  return `
-    <section class="hero">
-      <img class="pic" src="assets/images/pictures/profile.jpg" alt="Joe Rice"/>
-      <div class="intro">
-        <p>I'm a husband, father, IT generalist, and entrepreneur at heart. I love sharing knowledge and have over a decade of experience in IT. If you're looking to connect with someone who's down to earth, open minded yet skeptical, and passionate about self improvement, I'd love to hear from you. To hire me for freelance or full-time work, just fill out the contact form below. I'll respond within 24 hours.</p>
-        <div class="social">
-          ${socialLinksHtml}
-        </div>
-      </div>
-    </section>
-  `;
-}
 
 /**
  * Render home page content
  */
 export function renderHome() {
   const mainContent = $('#mainContent');
-  if (!mainContent) {
-    console.warn('Main content container not found');
-    return;
-  }
-
-  mainContent.innerHTML = getHomeTemplate();
+  if (mainContent) mainContent.innerHTML = '';
 }
 
 /**
  * Initialize home page
  */
-export function initHome() {
-  // Home page has no interactive elements to initialize
-  // Just static content rendered by renderHome()
-}
+export function initHome() {}
 
 /**
  * Clean up home page
  */
-export function destroyHome() {
-  // Nothing to clean up for home page
-}
+export function destroyHome() {}

--- a/styles.css
+++ b/styles.css
@@ -242,7 +242,7 @@ ol {
   flex-direction: column;
   align-items: center;
   gap: var(--space);
-  padding-block: clamp(20px, 8vw, 60px);
+  padding-block: clamp(16px, 3vw, 28px);
 }
 
 .pic {
@@ -253,11 +253,8 @@ ol {
   background: var(--rose);
 }
 
-.intro {
+.profileDesc {
   text-align: center;
-}
-
-.intro p {
   font-size: clamp(1.05rem, 2.4vw, 1.3rem);
   max-width: 40ch;
   margin-inline: auto;
@@ -1836,7 +1833,7 @@ footer {
 }
 
 @media (width <= 600px) {
-  .intro p {
+  .profileDesc {
     max-width: 30ch;
   }
 }


### PR DESCRIPTION
## Summary
Extracted the profile section (photo, social links, and description) from individual pages into a persistent component rendered once in the app shell. The profile description now updates dynamically based on the active route, eliminating code duplication across pages.

## Key Changes
- **New component**: Created `assets/js/components/profile.js` with `getProfileTemplate()` and `updateProfileDescription()` functions
- **App shell integration**: Added profile component to main app shell in `main.js`, positioned between header and main content
- **Route-aware descriptions**: Profile description updates automatically on route changes via the router's `onRouteChange` callback
- **Removed duplication**: Deleted identical social links arrays and profile markup from `home.js` and `hire.js`
- **Simplified pages**: Home page now renders empty (profile is in shell); hire page focuses only on services section
- **CSS updates**: Adjusted `.hero` padding and renamed `.intro p` to `.profileDesc` for consistency

## Implementation Details
- Social links configuration is centralized in the profile component
- Page descriptions are mapped to routes in a `pageDescriptions` object; unknown routes fall back to home description
- Profile description element starts empty and is populated before first paint via the route change listener
- All pages benefit from the persistent profile without needing to render it individually

https://claude.ai/code/session_011kj8Fh4Dda3YvzQYo6EVkD